### PR TITLE
Static assets now have fixed names

### DIFF
--- a/webpack.commons.js
+++ b/webpack.commons.js
@@ -185,7 +185,10 @@ module.exports = {
         test: /\.(woff(2)?|ttf|eot|svg)(\?v=\d+\.\d+\.\d+)?$/,
         use: [
           {
-            loader: 'file-loader'
+            loader: 'file-loader',
+            options: {
+              name: '[name].[ext]'
+            }
           }
         ]
       },


### PR DESCRIPTION
Context: We need these assets to have the same names each time we build the app so that we can load them in https://github.com/OpenPaaS-Suite/openpaas-gatling. I think this should be OK. Those are the assets that we do not frequently update so it's perfectly fine not to have a hash for them. Even if we have a problem with the browser's cache, it should not affect much (as long as the JavaScript files get updated).